### PR TITLE
Fix KeyVault configuration not being loaded from appsettings

### DIFF
--- a/src/B2CMigrationKit.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/B2CMigrationKit.Core/Extensions/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         services.Configure<StorageOptions>(configuration.GetSection($"{MigrationOptions.SectionName}:Storage"));
         services.Configure<RetryOptions>(configuration.GetSection($"{MigrationOptions.SectionName}:Retry"));
         services.Configure<TelemetryOptions>(configuration.GetSection($"{MigrationOptions.SectionName}:Telemetry"));
+        services.Configure<KeyVaultOptions>(configuration.GetSection($"{MigrationOptions.SectionName}:KeyVault"));
 
         // Register Application Insights (if configured)
         var telemetryOptions = configuration.GetSection($"{MigrationOptions.SectionName}:Telemetry").Get<TelemetryOptions>();


### PR DESCRIPTION
## Description

Fixes a configuration bug where `KeyVaultOptions` was not registered in the DI container, causing `SecretProvider` instantiation to fail at runtime.

## Problem

`SecretProvider` requires `IOptions<KeyVaultOptions>` in its constructor, but the configuration binding was missing:
```csharp
public SecretProvider(
    IOptions<KeyVaultOptions> options,  // ← Not registered in DI
    ILogger<SecretProvider> logger)
```

This caused a runtime error when trying to use Key Vault features:

## Solution

Added the missing configuration binding:
```csharp
services.Configure(
    configuration.GetSection($"{MigrationOptions.SectionName}:KeyVault"));
```
