### PR TITLE
Fix incorrect ID for CustomAuthenticationExtension.Receive.Payload

### DIFF
--- a/scripts/Configure-ExternalIdJit.ps1
+++ b/scripts/Configure-ExternalIdJit.ps1
@@ -340,7 +340,7 @@ if ($existingApps.value.Count -gt 0) {
                 resourceAppId = "00000003-0000-0000-c000-000000000000"  # Microsoft Graph
                 resourceAccess = @(
                     @{
-                        id = "214e68ed-7c8c-4ff7-a56c-6e60ae86e8cf"  # CustomAuthenticationExtension.Receive.Payload
+                        id = "214e810f-fda8-4fd7-a475-29461495eb00"  # CustomAuthenticationExtension.Receive.Payload
                         type = "Role"
                     }
                 )


### PR DESCRIPTION
## Description
Fixed incorrect ID for `CustomAuthenticationExtension.Receive.Payload` in the custom authentication extension app registration setup.

## Changes
- Updated the permission ID in `scripts/Configure-ExternalIdJit.ps1` from `214e68ed-7c8c-4ff7-a56c-6e60ae86e8cf` to `214e810f-fda8-4fd7-a475-29461495eb00`

## Reference
- [Microsoft Graph permissions reference - CustomAuthenticationExtension.Receive.Payload](https://learn.microsoft.com/en-us/graph/permissions-reference#customauthenticationextensionreceivepayload)

## Test results
- Script executed successfully with corrected ID
- App registration created with permission `CustomAuthenticationExtension.Receive.Payload` (ID: 214e810f-fda8-4fd7-a475-29461495eb00)
