### PR TITLE
Fix certificate date timezone issue by converting to UTC

### DIFF
--- a/scripts/Configure-ExternalIdJit.ps1
+++ b/scripts/Configure-ExternalIdJit.ps1
@@ -417,9 +417,9 @@ Write-Info "Configuring encryption key on app registration..."
 $keyCredentialsBody = @{
     keyCredentials = @(
         @{
-            endDateTime = $cert.NotAfter.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            endDateTime = $cert.NotAfter.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
             keyId = $keyGuid
-            startDateTime = $cert.NotBefore.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            startDateTime = $cert.NotBefore.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
             type = "AsymmetricX509Cert"
             usage = "Encrypt"
             key = $certBase64


### PR DESCRIPTION
## Description
Fixed certificate date format issue causing `KeyCredentialsInvalidEndDate` error by ensuring dates are converted to UTC before formatting.

This PR addresses the `KeyCredentialsInvalidEndDate` error reported in #10.

## Changes
- Added `ToUniversalTime()` conversion in certificate date formatting:
```powershell
  endDateTime = $cert.NotAfter.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
  startDateTime = $cert.NotBefore.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
```

## Why
According to the Microsoft Graph API documentation, the `endDateTime` property of keyCredential "represents date and time information using ISO 8601 format and **is always in UTC time**".

However, the .NET `X509Certificate2.NotAfter` property returns the date **in local time** as documented:

> "Gets the date in local time after which a certificate is no longer valid."

The script was using `$cert.NotAfter` directly without timezone conversion. This mismatch caused the error reported in #10:
```
Error Code: KeyCredentialsInvalidEndDate
Error Message: Key credential end date is invalid.
```

By explicitly converting to UTC with `ToUniversalTime()` before formatting, the date matches the UTC format required by the Graph API.

## Related Issue
Partially resolves #10 (fixes the `KeyCredentialsInvalidEndDate` error)

## Reference
- [keyCredential resource type - Microsoft Graph](https://learn.microsoft.com/en-us/graph/api/resources/keycredential?view=graph-rest-1.0) - states that endDateTime "is always in UTC time"
- [X509Certificate2.NotAfter Property - Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.notafter?view=net-8.0) - returns date "in local time"
- [X509Certificate2.NotBefore Property - Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.notbefore?view=net-8.0)

## Test results
- The `KeyCredentialsInvalidEndDate` error is resolved
