### PR TITLE
Fix resourceId domain mismatch for regional Azure Function URLs

### DIFF
--- a/scripts/Switch-JitEnvironment.ps1
+++ b/scripts/Switch-JitEnvironment.ps1
@@ -41,12 +41,13 @@ if ($Environment -eq "Local") {
     $identifierUri = "api://$NgrokDomain/$LocalAppId"
 } else {
     # Extract function app name from URL for Azure environment
-    $functionAppName = if ($AzureFunctionUrl -match "https://([^.]+)") { $matches[1] } else { "your-function-app" }
+    $functionHost = if ($AzureFunctionUrl -match "https://([^/]+)") { $matches[1] } else { "your-function-app" }
+
     $targetUrl = "$AzureFunctionUrl/api/JitAuthentication"
-    $resourceId = "api://$functionAppName.azurewebsites.net/$AzureAppId"
+    $resourceId = "api://$functionHost/$AzureAppId"
     $appObjectId = $AzureAppObjectId
     $appId = $AzureAppId
-    $identifierUri = "api://$functionAppName.azurewebsites.net/$AzureAppId"
+    $identifierUri = "api://$functionHost/$AzureAppId"
 }
 
 Write-Info "Target Configuration:"


### PR DESCRIPTION
## Description
Fixed `DomainNameDoesNotMatch` error that occurs when using Azure Functions deployed in specific regions (e.g., Japan East, West Europe) where the URL includes the region name.

## Changes
- Changed from extracting only the function app name to extracting the full hostname:
```powershell
  # Before
  $functionAppName = if ($AzureFunctionUrl -match "https://([^.]+)") { $matches[1] } else { "your-function-app" }
  $resourceId = "api://$functionAppName.azurewebsites.net/$AzureAppId"
  $identifierUri = "api://$functionAppName.azurewebsites.net/$AzureAppId"
  
  # After
  $functionHost = if ($AzureFunctionUrl -match "https://([^/]+)") { $matches[1] } else { "your-function-app" }
  $resourceId = "api://$functionHost/$AzureAppId"
  $identifierUri = "api://$functionHost/$AzureAppId"
```

## Why
When Azure Functions are deployed in specific regions, the URL includes the region name (e.g., `https://my-function.japaneast.azurewebsites.net`).

The original code only extracted the first part of the hostname (`my-function`), resulting in:
```
resourceId: api://my-function.azurewebsites.net/...
targetUrl: https://my-function.centralus-01.azurewebsites.net/...
```

This mismatch caused the following error when creating/updating custom authentication extensions:
```
DomainNameDoesNotMatch: The fully qualified domain name in resourceId should match that of the targetUrl
```

By extracting the full hostname instead, the `resourceId` now correctly matches the `targetUrl`:
```
resourceId: api://my-function.japaneast.azurewebsites.net/...
targetUrl: https://my-function.japaneast.azurewebsites.net/...
```

## Error Message
```
Failed to update Custom Extension: PATCH https://graph.microsoft.com/beta/identity/customAuthenticationExtensions/...
HTTP/2.0 400 Bad Request

{"error":{"code":"AADB2C","message":"DomainNameDoesNotMatch:The fully qualified domain name in resourceId should match that of the targetUrl"}}
```

## Test results
- Script executed successfully with regional Azure Function URL (`*.centralus-01.azurewebsites.net`)
- Custom authentication extension updated without `DomainNameDoesNotMatch` error
- Verified that `resourceId` and `targetUrl` domains now match